### PR TITLE
adds Docker tag overwrite option to run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,14 @@ RUN mkdir -p /usr/share/man/man1
 RUN apt-get update && apt-get install --no-install-recommends -y \
     default-jre \
     libgtk-3-0 \
+    sudo \
  && rm -rf /var/lib/apt/lists/*
 
 # Create unprivileged user to run Eclipse
 # User's UID and GID should match the builder's IDs in order not to screw up the file permissions and ownerships.
 RUN addgroup --gid 1000 $GROUP \
- && adduser --disabled-password --disabled-login --uid $UID --gid $GID --gecos '' $USER
+ && adduser --disabled-password --disabled-login --uid $UID --gid $GID --gecos '' $USER \
+ && echo "$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Get Eclipse from builder container
 COPY --from=builder /opt /opt

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ cat <<EOF > "${HOME}/.local/share/applications/eclipse-${DOCKER_TAG}.desktop"
 [Desktop Entry]
 Name=Eclipse - ${DOCKER_TAG}
 Type=Application
-Exec=${ROOT_DIR}/run.sh
+Exec=${ROOT_DIR}/run.sh ${DOCKER_TAG}
 Terminal=false
 Icon=${FILES_TMP_DIR}/${DOCKER_TAG}.xpm
 Comment=Integrated Development Environment

--- a/run.sh
+++ b/run.sh
@@ -44,6 +44,7 @@ containerName='eclipse-ide'
 # Check if a custom image tag should be used.
 if [[ ${#} -gt 0 ]]; then
   DOCKER_IMAGE="${DOCKER_IMAGE%:*}:${1}"
+  containerName="eclipse-${1}"
 fi
 
 # Create the container to be able to retrieve its hostname for xhost later on.

--- a/run.sh
+++ b/run.sh
@@ -41,6 +41,11 @@ function cleanUp() {
 
 containerName='eclipse-ide'
 
+# Check if a custom image tag should be used.
+if [[ ${#} -gt 0 ]]; then
+  DOCKER_IMAGE="${DOCKER_IMAGE%:*}:${1}"
+fi
+
 # Create the container to be able to retrieve its hostname for xhost later on.
 containerId=$(docker create \
   --name "${containerName}" \


### PR DESCRIPTION
Previously the starter script would start whatever Eclipse flavour the
repository was checked out in. This caused the installed starters to
ignore their flavour. This has been fixed by having the starter pass the
flavour explicitly to the run script.